### PR TITLE
Make repository working with Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  python:
+    version: 3.6.0


### PR DESCRIPTION
Circle-CI needs a `circle.yml` to work with Python 3.6.

Background PR info: This PR is supposed to be merged relatively fast, so other PRs can be rebased against it and benefit from working Circle CI integration.

Tests are in PR #11 (Circle CI will report failiure when no tests were found, but this is not a defect of this PR).