### PR TITLE
Add the request acquisition functionality to the business logic.

### DIFF
--- a/src/iwant_bot/request_acquisition.py
+++ b/src/iwant_bot/request_acquisition.py
@@ -1,0 +1,80 @@
+import abc
+import uuid
+import collections
+
+from iwant_bot import requests
+
+
+class RequestPreprocessingPipeline(object):
+    def __init__(self):
+        self._blocks = collections.defaultdict(list)
+
+    def add_block(self, request_type, block):
+        self._blocks[request_type].append(block)
+
+    def add_activity_request(self, person_id, activity, lifespan_in_minutes):
+        chained_request = requests.IWantRequest(person_id, activity, lifespan_in_minutes)
+        for block in self._blocks['activity']:
+            if chained_request is None:
+                break
+            chained_request = block.pass_request(chained_request)
+
+    def add_cancellation_request(self, person_id, cancelling_request_id):
+        chained_request = requests.CancellationRequest(person_id, cancelling_request_id)
+        for block in self._blocks['cancel']:
+            if chained_request is None:
+                break
+            chained_request = block.pass_request(chained_request)
+
+
+class AbstractBlock(abc.ABC):
+    @abc.abstractmethod
+    def pass_request(self, request):
+        return request
+
+
+class Notifier(AbstractBlock):
+    def __init__(self):
+        self._callbacks = []
+
+    def append_callback(self, callback):
+        self._callbacks.append(callback)
+
+    def pass_request(self, request):
+        for cb in self._callbacks:
+            cb(request)
+        return request
+
+
+class Breaker(AbstractBlock):
+    def pass_request(self, request):
+        return None
+
+
+class PassThrough(AbstractBlock):
+    def pass_request(self, request):
+        return super().pass_request(request)
+
+
+class UIDAssigner(AbstractBlock):
+    def pass_request(self, request):
+        request.id = uuid.uuid4()
+        return request
+
+
+class Saver(AbstractBlock):
+    def __init__(self, storage):
+        self._storage = storage
+
+    def pass_request(self, request):
+        self._storage.store_request(request)
+        return request
+
+
+class Canceller(AbstractBlock):
+    def __init__(self, storage):
+        self._storage = storage
+
+    def pass_request(self, request):
+        self._storage.remove_activity_request(request.cancelling_request_id, request.person_id)
+        return None

--- a/src/iwant_bot/requests.py
+++ b/src/iwant_bot/requests.py
@@ -35,3 +35,9 @@ class IWantRequest(Request):
                      and self.person_id == other_request.person_id
                      and overlaps)
         return conflicts
+
+
+class CancellationRequest(Request):
+    def __init__(self, person_id, cancelling_request_id):
+        super().__init__(person_id)
+        self.cancelling_request_id = cancelling_request_id

--- a/src/iwant_bot/storage.py
+++ b/src/iwant_bot/storage.py
@@ -60,14 +60,15 @@ class MemoryRequestsStorage(RequestStorage):
         return ret
 
     def remove_activity_request(self, request_id, person_id):
-        print(request_id, person_id)
         request_to_remove = None
         for request in self._requests["activity"]:
             if request.id == request_id and request.person_id == person_id:
                 request_to_remove = request
                 break
         if request_to_remove is None:
-            raise KeyError(
-                f"There is no request of ID '{request_id}"
+            exception = KeyError(
+                f"There is no request of ID '{request_id}' by '{person_id}'",
+                request_id, person_id,
             )
+            raise exception
         self._requests["activity"].remove(request)

--- a/src/iwant_bot/storage.py
+++ b/src/iwant_bot/storage.py
@@ -72,3 +72,50 @@ class MemoryRequestsStorage(RequestStorage):
             )
             raise exception
         self._requests["activity"].remove(request)
+
+
+class TaskStorage(abc.ABC):
+    @abc.abstractmethod
+    def __init__(self):
+        pass
+
+    @abc.abstractmethod
+    def store_task(self, task_id, task_content):
+        """
+        Stores a task so it can be retreived.
+        """
+        pass
+
+    @abc.abstractmethod
+    def retreive_task(self, task_id):
+        """
+        """
+        pass
+
+    @abc.abstractmethod
+    def retreive_any_task(self):
+        """
+        """
+        pass
+
+
+class MemoryTaskStorage(TaskStorage):
+    def __init__(self):
+        self._tasks = dict()
+
+    def store_task(self, task_id, task_content):
+        self._tasks[task_id] = task_content
+
+    def retreive_task(self, task_id):
+        try:
+            ret = self._tasks.pop(task_id)
+        except KeyError:
+            ret = None
+        return ret
+
+    def retreive_any_task(self):
+        try:
+            ret = self._tasks.popitem()
+        except KeyError:
+            ret = None
+        return ret

--- a/src/iwant_bot/storage.py
+++ b/src/iwant_bot/storage.py
@@ -30,6 +30,16 @@ class RequestStorage(abc.ABC):
         """
         pass
 
+    @abc.abstractmethod
+    def remove_activity_request(self, request_id, person_id):
+        """
+        Remove a request from storage
+
+        Raises:
+            KeyError if there is no request of such ID issued by that person.
+        """
+        pass
+
 
 class MemoryRequestsStorage(RequestStorage):
     def __init__(self):
@@ -48,3 +58,16 @@ class MemoryRequestsStorage(RequestStorage):
             ret = [req for req in ret
                    if req.activity == activity]
         return ret
+
+    def remove_activity_request(self, request_id, person_id):
+        print(request_id, person_id)
+        request_to_remove = None
+        for request in self._requests["activity"]:
+            if request.id == request_id and request.person_id == person_id:
+                request_to_remove = request
+                break
+        if request_to_remove is None:
+            raise KeyError(
+                f"There is no request of ID '{request_id}"
+            )
+        self._requests["activity"].remove(request)

--- a/tests/unit/test_request_acquisition.py
+++ b/tests/unit/test_request_acquisition.py
@@ -41,6 +41,18 @@ def add_requests_canceller(pipeline, req_storage):
     pipeline.add_block('cancel', block)
 
 
+def add_cancelled_requests_notifier(pipeline, list_container):
+    block = request_acquisition.NotifierOfCancelled()
+    block.append_callback(lambda req: list_container.append(req))
+    pipeline.add_block('cancel', block)
+
+
+def add_not_cancelled_requests_notifier(pipeline, list_container):
+    block = request_acquisition.NotifierOfNotCancelled()
+    block.append_callback(lambda req: list_container.append(req))
+    pipeline.add_block('cancel', block)
+
+
 def test_notifier(pipeline):
     requests = []
     add_notifier(pipeline, requests)

--- a/tests/unit/test_request_acquisition.py
+++ b/tests/unit/test_request_acquisition.py
@@ -21,6 +21,11 @@ def add_breaker(pipeline):
     pipeline.add_block('activity', block)
 
 
+def add_noop(pipeline):
+    block = request_acquisition.PassThrough()
+    pipeline.add_block('activity', block)
+
+
 def add_uid_assigner(pipeline):
     block = request_acquisition.UIDAssigner()
     pipeline.add_block('activity', block)
@@ -46,6 +51,7 @@ def test_notifier(pipeline):
 
 def test_breaker(pipeline):
     requests = []
+    add_noop(pipeline)
     add_breaker(pipeline)
     add_notifier(pipeline, requests)
     pipeline.add_activity_request('john', 'coffee', 5)
@@ -71,10 +77,28 @@ def test_saver(pipeline):
 def test_canceller(pipeline):
     req_storage = storage.MemoryRequestsStorage()
     add_uid_assigner(pipeline)
+
     add_requests_saver(pipeline, req_storage)
     add_requests_canceller(pipeline, req_storage)
+
+    requests_cancelled = []
+    add_cancelled_requests_notifier(pipeline, requests_cancelled)
+
+    requests_not_cancelled = []
+    add_not_cancelled_requests_notifier(pipeline, requests_not_cancelled)
+
     pipeline.add_activity_request('john', 'coffee', 5)
     assert len(req_storage.get_activity_requests()) == 1
+
     id_to_cancel = req_storage.get_activity_requests()[0].id
     pipeline.add_cancellation_request('john', id_to_cancel)
+
     assert len(req_storage.get_activity_requests()) == 0
+    assert len(requests_cancelled) == 1
+    assert len(requests_not_cancelled) == 0
+
+    pipeline.add_cancellation_request('john', id_to_cancel)
+
+    assert len(req_storage.get_activity_requests()) == 0
+    assert len(requests_cancelled) == 1
+    assert len(requests_not_cancelled) == 1

--- a/tests/unit/test_request_acquisition.py
+++ b/tests/unit/test_request_acquisition.py
@@ -1,0 +1,80 @@
+import pytest
+
+from iwant_bot import request_acquisition
+from iwant_bot import storage
+
+
+@pytest.fixture
+def pipeline():
+    pipeline = request_acquisition.RequestPreprocessingPipeline()
+    return pipeline
+
+
+def add_notifier(pipeline, list_container):
+    block = request_acquisition.Notifier()
+    block.append_callback(lambda req: list_container.append(req))
+    pipeline.add_block('activity', block)
+
+
+def add_breaker(pipeline):
+    block = request_acquisition.Breaker()
+    pipeline.add_block('activity', block)
+
+
+def add_uid_assigner(pipeline):
+    block = request_acquisition.UIDAssigner()
+    pipeline.add_block('activity', block)
+
+
+def add_requests_saver(pipeline, req_storage):
+    block = request_acquisition.Saver(req_storage)
+    pipeline.add_block('activity', block)
+
+
+def add_requests_canceller(pipeline, req_storage):
+    block = request_acquisition.Canceller(req_storage)
+    pipeline.add_block('cancel', block)
+
+
+def test_notifier(pipeline):
+    requests = []
+    add_notifier(pipeline, requests)
+    pipeline.add_activity_request('john', 'coffee', 5)
+    assert len(requests) == 1
+    assert requests[0].person_id == 'john'
+
+
+def test_breaker(pipeline):
+    requests = []
+    add_breaker(pipeline)
+    add_notifier(pipeline, requests)
+    pipeline.add_activity_request('john', 'coffee', 5)
+    assert len(requests) == 0
+
+
+def test_uid_assigner(pipeline):
+    requests = []
+    add_uid_assigner(pipeline)
+    add_notifier(pipeline, requests)
+    pipeline.add_activity_request('john', 'coffee', 5)
+    pipeline.add_activity_request('john', 'coffee', 5)
+    assert requests[0].id != requests[1].id
+
+
+def test_saver(pipeline):
+    req_storage = storage.MemoryRequestsStorage()
+    add_requests_saver(pipeline, req_storage)
+    pipeline.add_activity_request('john', 'coffee', 5)
+    assert req_storage.get_activity_requests()[0].person_id == 'john'
+
+
+def test_canceller(pipeline):
+    req_storage = storage.MemoryRequestsStorage()
+    add_uid_assigner(pipeline)
+    add_requests_saver(pipeline, req_storage)
+    add_requests_canceller(pipeline, req_storage)
+    pipeline.add_activity_request('john', 'coffee', 5)
+    assert len(req_storage.get_activity_requests()) == 1
+    id_to_cancel = req_storage.get_activity_requests()[0].id
+    pipeline.add_cancellation_request('john', id_to_cancel)
+    assert len(req_storage.get_activity_requests()) == 0

--- a/tests/unit/test_start.py
+++ b/tests/unit/test_start.py
@@ -1,6 +1,0 @@
-from iwant_bot import start
-
-
-def test_add():
-    assert start.add_numbers(0, 0) == 0
-    assert start.add_numbers(1, 1) == 2

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,47 +1,57 @@
 import pytest
 
-from iwant_bot.storage import MemoryRequestsStorage
-from iwant_bot.requests import IWantRequest
+from iwant_bot import storage, requests
 
 
 def test_storage_saves_and_restores():
-    storage = MemoryRequestsStorage()
-    request = IWantRequest("john", "coffee", 0)
-    storage.store_request(request)
-    recovered_request = storage.get_activity_requests()[0]
+    store = storage.MemoryRequestsStorage()
+    request = requests.IWantRequest("john", "coffee", 0)
+    store.store_request(request)
+    recovered_request = store.get_activity_requests()[0]
     assert request == recovered_request
     with pytest.raises(ValueError) as err:
-        storage.store_request(42)
+        store.store_request(42)
     assert "int" in str(err)
 
 
 def test_storage_removes():
-    storage = MemoryRequestsStorage()
-    request = IWantRequest("john", "coffee", 0)
-    storage.store_request(request)
-    request = IWantRequest("john", "coffee", 0)
+    store = storage.MemoryRequestsStorage()
+    request = requests.IWantRequest("john", "coffee", 0)
+    store.store_request(request)
+    request = requests.IWantRequest("john", "coffee", 0)
     request.id = "foo"
-    storage.store_request(request)
+    store.store_request(request)
     with pytest.raises(KeyError):
-        storage.remove_activity_request("bar", "jack")
+        store.remove_activity_request("bar", "jack")
     with pytest.raises(KeyError):
-        storage.remove_activity_request("foo", "jack")
-    storage.remove_activity_request("foo", "john")
-    assert len(storage.get_activity_requests()) == 1
+        store.remove_activity_request("foo", "jack")
+    store.remove_activity_request("foo", "john")
+    assert len(store.get_activity_requests()) == 1
 
 
 def test_storage_filters_activities():
-    storage = MemoryRequestsStorage()
-    storage.store_request(IWantRequest("john", "coffee", 1))
-    storage.store_request(IWantRequest("jack", "coffee", 6))
-    storage.store_request(IWantRequest("jane", "tea", 2))
+    store = storage.MemoryRequestsStorage()
+    store.store_request(requests.IWantRequest("john", "coffee", 1))
+    store.store_request(requests.IWantRequest("jack", "coffee", 6))
+    store.store_request(requests.IWantRequest("jane", "tea", 2))
 
-    recovered_tea_requests = storage.get_activity_requests("tea")
+    recovered_tea_requests = store.get_activity_requests("tea")
     assert len(recovered_tea_requests) == 1
     assert recovered_tea_requests[0].person_id == "jane"
 
-    recovered_coffee_requests = storage.get_activity_requests("coffee")
+    recovered_coffee_requests = store.get_activity_requests("coffee")
     assert len(recovered_coffee_requests) == 2
 
-    recovered_coffee_requests = storage.get_activity_requests()
+    recovered_coffee_requests = store.get_activity_requests()
     assert len(recovered_coffee_requests) == 3
+
+
+def test_task_storage():
+    store = storage.MemoryTaskStorage()
+    store.store_task("coffee", "added")
+    store.store_task("coffee", "cancelled")
+    task = store.retreive_task("coffee")
+    assert task == "cancelled"
+    assert store.retreive_task("coffee") is None
+    store.store_task("covfefe", "tweeted")
+    assert store.retreive_any_task() == ("covfefe", "tweeted")

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -15,6 +15,21 @@ def test_storage_saves_and_restores():
     assert "int" in str(err)
 
 
+def test_storage_removes():
+    storage = MemoryRequestsStorage()
+    request = IWantRequest("john", "coffee", 0)
+    storage.store_request(request)
+    request = IWantRequest("john", "coffee", 0)
+    request.id = "foo"
+    storage.store_request(request)
+    with pytest.raises(KeyError):
+        storage.remove_activity_request("bar", "jack")
+    with pytest.raises(KeyError):
+        storage.remove_activity_request("foo", "jack")
+    storage.remove_activity_request("foo", "john")
+    assert len(storage.get_activity_requests()) == 1
+
+
 def test_storage_filters_activities():
     storage = MemoryRequestsStorage()
     storage.store_request(IWantRequest("john", "coffee", 1))


### PR DESCRIPTION
Add the layer between request creation and saving request to the storage.
The following is supported:
* Assign a UUID to requests.
* Notify a subscriber when a request comes.
* Save a request to storage.
* Handle UUID-based cancel requests.